### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+FSFLAG = -lstdc++fs
+TARGET = bin2c
+FILE = bin2c.cpp
+
+$(TARGET):
+	$(CXX) -O3 -std=c++14 $(FILE) $(FSFLAG) -o $(TARGET)
+test:
+	rm -f ./tests/VP.hpp
+	./bin2c /custvar "IMAGE_VP" /nohead /infile "./tests/VP.jpg" /outfile "./tests/VP.hpp"
+	$(CXX) -O3 -std=c++14 ./tests/VP.cpp -o ./tests/VP
+	./tests/VP
+
+.PHONY: clean
+clean:
+	rm -f ./tests/VP.hpp
+	rm -f ./bin2c

--- a/tests/VP.cpp
+++ b/tests/VP.cpp
@@ -21,6 +21,5 @@ int main()
 	f.write(reinterpret_cast<char const *>(IMAGE_VP), IMAGE_VP_SIZE);
 	f.close();
 	std::cout << created_msg << std::endl;
-	std::cin.ignore();
 	return 0;
 }


### PR DESCRIPTION
#4 tries to move project to cmake, but I believe that this is an overkill for several reasons:
- There is only 1 file to compile
- There is only 1 test file to compile and run

So I used simpler Makefile. Usage
`make` - compiles bin2c.cpp to bin2c executable
`make test` - runs bin2c, compiles test file and executes it
'make clean' - removes files generated by Makefile - bin2c and VP.hpp

I think this solution is much simpler and easier to understand. `make` just runs commands after target.
To set compiler you just need to write `export CXX=clang++ && make`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arahaan/bin2c/5)
<!-- Reviewable:end -->
